### PR TITLE
Assertion correction to include trailing characters

### DIFF
--- a/test/02_about_composable_observations.js
+++ b/test/02_about_composable_observations.js
@@ -60,7 +60,7 @@ test('create a more relevant stream', function () {
 
   relativemouse.subscribe(function (x) { received += x + ', '; });
 
-  equal('50, 150, 100', received);
+  equal('50, 150, 100, ', received);
 });
 
 test('checking everything', function () {


### PR DESCRIPTION
Changed the assertion for the "Composable Observations create a more relevant stream" test to include the trailing comma and space.
