### PR TITLE
Fix var declaration in about_stream

### DIFF
--- a/test/01_about_streams.js
+++ b/test/01_about_streams.js
@@ -129,8 +129,8 @@ test('events before you subscribe do not count', function () {
 
 test('events after you unsubscribe dont count', function () {
   var sum = 0,
-      numbers = new Subject();
-      observable = numbers.tap(function (n) { sum += n; });
+      numbers = new Subject(),
+      observable = numbers.tap(function (n) { sum += n; }),
       subscription = observable.subscribe();
 
   numbers.onNext(1);


### PR DESCRIPTION
minor syntax error caused variables to be defined in the global scope,
which caused the test to fail even after the correct answer was given