### PR TITLE
Update first test case for Scheduler to remove deprecated method.

### DIFF
--- a/test/04_about_time.js
+++ b/test/04_about_time.js
@@ -8,9 +8,10 @@ QUnit.module('Time');
 var __ = 'Fill in the blank';
 
 asyncTest('launching an event via a scheduler', function () {
+  var state = null;
   var received = '';
   var delay = 600; // Fix this value
-  Scheduler.timeout.scheduleWithRelative(delay, function () {
+  Scheduler.default.scheduleFuture(state, delay, function (scheduler, state) {
     received = 'Finished';
   });
 


### PR DESCRIPTION
Fix for #8 

Rx.Scheduler.timeout is deprecated (see https://github.com/Reactive-Extensions/RxJS/blob/scheduler_refactor/doc/api/schedulers/scheduler.md#scheduler-class-properties)
