### PR TITLE
Fix "___" is not defined

### DIFF
--- a/test/07_about_mapping.js
+++ b/test/07_about_mapping.js
@@ -20,7 +20,7 @@ test('flatMapLatest only gets us the latest value', function () {
   var results = [];
   Observable.range(1, 3)
     .flatMapLatest(function (x) {
-      return Observable.range(x, ___);
+      return Observable.range(x, __);
     })
     .subscribe(results.push.bind(results));
 


### PR DESCRIPTION
Triple underscore to double. Otherwise I was getting:

```
 1) Mapping flatMapLatest only gets us the latest value:
     ReferenceError: ___ is not defined
      at test/07_about_mapping.js:23:34
```
